### PR TITLE
Update mongoose-tag-everything.js

### DIFF
--- a/lib/mongoose-tag-everything.js
+++ b/lib/mongoose-tag-everything.js
@@ -62,7 +62,7 @@ module.exports = (function() {
       Tag = this.constructor.db.model(options.ModelName);
       normalizedCase = _.invokeMap(tags, 'toLowerCase');
 
-      Tag.find({ value: { $in: tags }}, function(err, existingTags) {
+      Tag.find({ value: { $in: normalizedCase }}, function(err, existingTags) {
         var values = _.map(existingTags, 'value');
         var missingTags = _.difference(normalizedCase, values);
         


### PR DESCRIPTION
Fixed normalizedCase not being used in the second pre-save hook resulting in duplicate key error index.